### PR TITLE
Fix: lighthouse-ciのトリガーと結果の投稿場所を変更

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -61,4 +61,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           URL: ${{ github.event.pull_request.html_url }}
         run:
-          gh pr comment -F ./comments "${URL}"
+          gh pr comment -F ./comments "${{ github.event.issue.pull_request.html_url }}"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lighthouse-ci:
     name: lighthouse-ci
-    if: (github.event.issue.pull_request != null) && github.event.comment.body == '!github run lh'
+    if: (github.event.issue.pull_request != null) && github.event.comment.body == '/run lighthouse'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/6deb19b3248771740587/maintainability)](https://codeclimate.com/github/gongon84/learning-golangci/maintainability)[![Test Coverage](https://api.codeclimate.com/v1/badges/6deb19b3248771740587/test_coverage)](https://codeclimate.com/github/gongon84/learning-golangci/test_coverage)[![lint status](https://github.com/goark/koyomi/workflows/lint/badge.svg)](https://github.com/gongon84/learning-golangci/actions)
 
-<br>
-
 # 概要
 * [code climate](https://codeclimate.com/)
 
@@ -27,10 +25,14 @@
 
 * CI連携
 
-    ![スクショ](https://github.com/gongon84/learning-golangci/assets/57177320/d74f43d2-8717-40b5-a0de-26af0be98a90)
+    <img src="https://github.com/gongon84/learning-golangci/assets/57177320/d74f43d2-8717-40b5-a0de-26af0be98a90" width="600">
 
 * lighthouse 計測
+    * コメント
 
-    ![スクリーンショット 2023-09-22 18 50 05](https://github.com/gongon84/learning-analysis-tool/assets/57177320/0d965d01-4a76-494f-a9e5-6e4d048c5d9d)
+       <img src="https://github.com/gongon84/learning-analysis-tool/assets/57177320/0d965d01-4a76-494f-a9e5-6e4d048c5d9d" width="500"> 
 
-    ![スクリーンショット 2023-09-22 18 50 44](https://github.com/gongon84/learning-analysis-tool/assets/57177320/3f298c16-05be-409f-a374-a399638940f1)
+    * 計測結果
+
+       <img src="https://github.com/gongon84/learning-analysis-tool/assets/57177320/3f298c16-05be-409f-a374-a399638940f1" width="500">
+  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 * [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci)
 
-    * プルリクエストへのコメント（!github run lh）をトリガーに以下を実行
+    * プルリクエストへのコメント（/run lighthouse）をトリガーに以下を実行
         * lighthouseでサイトパフォーマンスを計測（ngrokで一時公開したものを計測）
         * 計測結果のURLをプルリクでコメントしてくれる
 


### PR DESCRIPTION
# 概要
* トリガーを「/run lighthouse」をコメントした時に変更
* lighthouse.ymlはmainブランチのが適用されており、結果を投稿する際に、mainブランチにPRはないとエラーが出ていたため
  * エラー文：`no pull requests found for branch "main"`